### PR TITLE
Create Cuis-Web pck with WebClient as dependency

### DIFF
--- a/Cuis-Web.pck.st
+++ b/Cuis-Web.pck.st
@@ -1,0 +1,36 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3686] on 30 March 2019 at 5:20:58 pm'!
+'Description Microframework web for Cuis Smalltalk
+'!
+!provides: 'Cuis-Web' 1 0!
+!requires: 'WebClient' 1 17 nil!
+SystemOrganization addCategory: #'Cuis-Web'!
+
+
+!classDefinition: #CuisWebServer category: #'Cuis-Web'!
+Object subclass: #CuisWebServer
+	instanceVariableNames: 'webServer'
+	classVariableNames: ''
+	poolDictionaries: ''
+	category: 'Cuis-Web'!
+!classDefinition: 'CuisWebServer class' category: #'Cuis-Web'!
+CuisWebServer class
+	instanceVariableNames: ''!
+
+
+!CuisWebServer methodsFor: 'as yet unclassified' stamp: 'GC 3/30/2019 17:17:40'!
+initialize
+
+	webServer _ WebServer new! !
+
+!CuisWebServer methodsFor: 'as yet unclassified' stamp: 'GC 3/30/2019 17:15:56'!
+start
+
+	webServer listenOn: self defaultPort! !
+
+!CuisWebServer methodsFor: 'accessing' stamp: 'GC 3/30/2019 17:16:49'!
+defaultPort
+	^ 8080! !
+
+!CuisWebServer class methodsFor: 'instance creation' stamp: 'GC 3/30/2019 17:16:37'!
+start
+	self new start! !


### PR DESCRIPTION
## What

Fixes #1 

This is about create a pck ready to import in cuis.
After import this, you would be able to run `CuisWebServer start`, that would start the web server in 8080 port by default.

If you go to `http://localhost:8080/` you will get a 404 error.